### PR TITLE
Set status code per express 4 standard

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -130,7 +130,7 @@ Swagger.prototype.setResourceListingPaths = function(app) {
         var data = self.filterApiListing(req, res, r);
         data.basePath = self.basePath;
         if (data.code) {
-          res.send(data, data.code);
+          res.status(data.code).send(data);
         } else {
           res.send(JSON.stringify(data));
         }
@@ -149,7 +149,7 @@ Swagger.prototype.setCustomErrorResponse = function(errorType, code, responseObj
     if (!res) {
       return responseObj;
     } else {
-      res.send(responseObj, code);
+      res.status(code).send(responseObj);
     }
   };
 };
@@ -434,7 +434,7 @@ Swagger.prototype.addMethod = function(app, callback, spec) {
             'message': 'forbidden'
           }
         };
-        res.send(JSON.stringify(errResponse.response), errResponse.code);
+        res.status(errResponse.code).send(JSON.stringify(errResponse.response));
       } else {
         callback(req, res, next);
       }
@@ -548,12 +548,12 @@ Swagger.prototype.addValidator = function(v) {
 Swagger.prototype.stopWithError = function(res, error) {
   this.setHeaders(res);
   if (error && error.message && error.code)
-    res.send(JSON.stringify(error), error.code);
+    res.status(error.code).send(JSON.stringify(error));
   else
-    res.send(JSON.stringify({
+    res.status(500).send(JSON.stringify({
       'message': 'internal error',
       'code': 500
-    }), 500);
+    }));
 };
 
 Swagger.prototype.setApiInfo = function(data) {
@@ -573,10 +573,10 @@ Swagger.prototype.errors = {
         'message': field + ' not found'
       };
     } else {
-      res.send({
+      res.status(404).send({
         'code': 404,
         'message': field + ' not found'
-      }, 404);
+      });
     }
   },
   'invalid': function (field, res) {
@@ -586,10 +586,10 @@ Swagger.prototype.errors = {
         'message': 'invalid ' + field
       };
     } else {
-      res.send({
+      res.status(400).send({
         'code': 400,
         'message': 'invalid ' + field
-      }, 404);
+      });
     }
   },
   'forbidden': function (res) {
@@ -599,10 +599,10 @@ Swagger.prototype.errors = {
         'message': 'forbidden'
       };
     } else {
-      res.send({
+      res.status(403).send({
         'code': 403,
         'message': 'forbidden'
-      }, 403);
+      });
     }
   }
 };


### PR DESCRIPTION
Express 4 no longer accepts status codes as a second arg on res.send().  This PR just fixes the responses to properly set status in the separate method.

Once this is merged, we'll need to recut a release and update the package rev for 360.